### PR TITLE
cam18894 - ajout d'une action pour generer un kpz a chaque fois qu'on push un tag

### DIFF
--- a/.github/workflows/generate_kpz.yml
+++ b/.github/workflows/generate_kpz.yml
@@ -1,0 +1,63 @@
+name: Generate KPZ file
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on new tags events but only for the "master" branch
+  push:
+    tags:
+      - '*'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  release:
+    name: Build & Release
+    runs-on: ubuntu-latest
+    permissions: write-all
+    if: startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Parse out and store the GitHub repository name
+      id: myvars
+      run: |
+        IFS='/' read -r -a parts <<< "$GITHUB_REPOSITORY"
+        GITHUB_REPO="${parts[1]}"
+        echo "github_repo=$GITHUB_REPO" >> $GITHUB_OUTPUT
+        echo "GITHUB REPO: $GITHUB_REPO"
+
+        TAG_VERSION="${GITHUB_REF##*/}"
+        echo "TAG VERSION: $TAG_VERSION"
+        TAG_VERSION="${TAG_VERSION:1}"
+        echo "TAG VERSION 2: $TAG_VERSION"
+        echo "tag_version=$TAG_VERSION" >> $GITHUB_OUTPUT
+
+    - name: Dump myvars outputs
+      env:
+        GITHUB_CONTEXT: ${{ toJson(steps.myvars.outputs) }}
+      run: echo "$GITHUB_CONTEXT"
+
+    - name: Build Koha Plugin kpz artifact
+      id: kpz
+      uses: "bywatersolutions/github-action-koha-plugin-create-kpz@master"
+      with:
+        release-version: ${{ steps.myvars.outputs.tag_version }}
+        release-name: ${{ steps.myvars.outputs.github_repo }}
+        minimum-version: "17.05"
+        plugin-module: "Koha/Plugin/PDFtoCover.pm"
+
+    - name: See if kpz was created
+      run: |
+        echo "FILENAME: ${{ steps.kpz.outputs.filename }}"
+        ls -alh
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: |
+          ${{ steps.kpz.outputs.filename }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
cam18894 - essai2 ajout de permissions

cam18894 - essai3 changement de methode pour zip

cam18894 - essai4 ajout commit apres la creation du zip

cam18894 - essai5 checkout avant de commit

cam18894 - essai6 test commit push

cam18894 - essai7 test zip et commit push

cam18894 - essai8 ajout checkout master

cam18894 - essai9 ajout permissions

Creation du nouveau fichier .kpz

cam18894 - essai10 test ajout .kpz dans la release

Creation du nouveau fichier .kpz

cam18894 - essai11 remplacement du .zip en .kpz

Creation du nouveau fichier .kpz

cam18894 - essai12 remplacement https par ssh

Creation du nouveau fichier .kpz

cam18894 - essai13 changement de lib pour creer la release

Creation du nouveau fichier .kpz

Creation du nouveau fichier .kpz

cam18894 - essai14 changement nom release et retrait brouillon

Creation du nouveau fichier .kpz

cam18894 - essai15 execution des jobs l'un apres l'autre

Creation du nouveau fichier .kpz

cam18894 - essai16 ajout suppression kpz

Creation du nouveau fichier .kpz

cam18894 - essai17 changement complet de yaml

cam18894 - essai18 retrait fichier inexistant

cam18894 - essai19 ajout permissions

Delete PDFtoCover.kpz

cam18894 - essai20 modification minimum version koha

cam18894 - essai21 modification set_output et suppression koha version

cam18894 - essai22 fix bug set_output et suppression koha version (reel cette fois)

cam18894 - essai22 modification koha minimum version

ajout de guillemets autour du numero de version

cam18894 - essai23 retrait accolade pour github_output

cam18894 - essai24 retrait de l'option pour lancer l'action a la main