### PR TITLE
fix (Plugin PDFtoCover): Erreur du token CSRF

### DIFF
--- a/Koha/Plugin/PDFtoCover/step_1.tt
+++ b/Koha/Plugin/PDFtoCover/step_1.tt
@@ -21,15 +21,18 @@
         <hr>
 
         <form onbsubmit="launchGenerate()" method="post" id="formTraitement">
+            [% INCLUDE 'csrf-token.inc' %]
             <!-- Necessary for the plugin to run, do not remove  -->
             <input type="hidden" name="class" value="[% CLASS %]"/>
             <input type="hidden" name="method" value="[% METHOD %]"/>
             <!-- end of plugin necessary inputs  -->
 
             <input name="greet" id="launch" type="submit" class="btn btn-default" value="Create thumbnails"/>
+            <input type="hidden" name="csrf-token" id="csrf-token-input" value=""/>
         </form>
 
         <form method="post" id="formStop">
+            [% INCLUDE 'csrf-token.inc' %]
             <!-- Necessary for the plugin to run, do not remove  -->
             <input type="hidden" name="class" value="[% CLASS %]"/>
             <input type="hidden" name="method" value="[% METHOD %]"/>
@@ -37,6 +40,7 @@
             <input type="hidden" name="id_job" value="[% id_job %]"/>
 
             <input name="stop" id="stop" type="submit" class="btn btn-default" value="Stop process" disabled/>
+            <input type="hidden" name="csrf-token" id="csrf-token-input" value=""/>
         </form>
 
         <p id="progression">&nbsp;</p>
@@ -91,6 +95,10 @@
 </style>
 
 <script>
+
+var csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+document.getElementById('csrf-token-input').value = csrfToken;
+
 $( function() {
     [% IF wait == 1 %]
         document.getElementById('launch').disabled = true;

--- a/Koha/Plugin/PDFtoCover/step_1_fr-CA.tt
+++ b/Koha/Plugin/PDFtoCover/step_1_fr-CA.tt
@@ -21,15 +21,18 @@
         <hr>
 
         <form onbsubmit="launchGenerate()" method="post" id="formTraitement">
+            [% INCLUDE 'csrf-token.inc' %]
             <!-- Necessary for the plugin to run, do not remove  -->
             <input type="hidden" name="class" value="[% CLASS %]"/>
             <input type="hidden" name="method" value="[% METHOD %]"/>
             <!-- end of plugin necessary inputs  -->
 
             <input name="greet" id="launch" type="submit" class="btn btn-default" value="Générer les vignettes"/>
+            <input type="hidden" name="csrf-token" id="csrf-token-input" value=""/>
         </form>
 
         <form method="post" id="formStop">
+            [% INCLUDE 'csrf-token.inc' %]
             <!-- Necessary for the plugin to run, do not remove  -->
             <input type="hidden" name="class" value="[% CLASS %]"/>
             <input type="hidden" name="method" value="[% METHOD %]"/>
@@ -37,6 +40,7 @@
             <input type="hidden" name="id_job" value="[% id_job %]"/>
 
             <input name="stop" id="stop" type="submit" class="btn btn-default" value="Arrêt du processus" disabled/>
+            <input type="hidden" name="csrf-token" id="csrf-token-input" value=""/>
         </form>
         
         <p id="progression">&nbsp;</p>
@@ -91,6 +95,10 @@
 </style>
 
 <script>
+
+var csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+document.getElementById('csrf-token-input').value = csrfToken;
+
 $( function() {
     [% IF wait == 1 %]
         document.getElementById('launch').disabled = true;

--- a/Koha/Plugin/PDFtoCover/step_1_fr.tt
+++ b/Koha/Plugin/PDFtoCover/step_1_fr.tt
@@ -21,15 +21,18 @@
         <hr>
 
         <form onbsubmit="launchGenerate()" method="post" id="formTraitement">
+            [% INCLUDE 'csrf-token.inc' %]
             <!-- Necessary for the plugin to run, do not remove  -->
             <input type="hidden" name="class" value="[% CLASS %]"/>
             <input type="hidden" name="method" value="[% METHOD %]"/>
             <!-- end of plugin necessary inputs  -->
 
             <input name="greet" id="launch" type="submit" class="btn btn-default" value="Générer les vignettes"/>
+            <input type="hidden" name="csrf-token" id="csrf-token-input" value=""/>
         </form>
 
         <form method="post" id="formStop">
+            [% INCLUDE 'csrf-token.inc' %]
             <!-- Necessary for the plugin to run, do not remove  -->
             <input type="hidden" name="class" value="[% CLASS %]"/>
             <input type="hidden" name="method" value="[% METHOD %]"/>
@@ -37,6 +40,7 @@
             <input type="hidden" name="id_job" value="[% id_job %]"/>
 
             <input name="stop" id="stop" type="submit" class="btn btn-default" value="Arrêt du processus" disabled/>
+            <input type="hidden" name="csrf-token" id="csrf-token-input" value=""/>
         </form>
 
         <p id="progression">&nbsp;</p>
@@ -91,6 +95,10 @@
 </style>
 
 <script>
+
+var csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+document.getElementById('csrf-token-input').value = csrfToken;
+
 $( function() {
     [% IF wait == 1 %]
         document.getElementById('launch').disabled = true;


### PR DESCRIPTION
Correction : Ajout du token CSRF manquant dans les formulaires pour permettre la validation de sécurité lors de la soumission.

Déploiement : Les fichiers .kpz mis à jour ont déjà été déployés sur inlibro.com.

Prochaine étape : Création du tag de release sur GitHub dès que cette PR sera acceptée et fusionnée.